### PR TITLE
Added link to release notes

### DIFF
--- a/2015/05/07/cakephp_3_0_4_released.rst
+++ b/2015/05/07/cakephp_3_0_4_released.rst
@@ -39,6 +39,9 @@ In addition to the security issues the following defects have been fixed:
   cache the result of custom accessors, and invalidate the cache when
   properties are changed or removed.
 
+For a deeper insight of what changed, have a look at the
+`release notes <http://cakephp.org/changelogs/3.0.4>`_.
+
 CakeFest 2015 Tickets
 ---------------------
 


### PR DESCRIPTION
The release notes are currently very hidden on the website and not easily to find. There should stand nothing against adding the link to the news.