### PR TITLE
Fix fix

### DIFF
--- a/2015/05/28/cakephp_2_6_6_and_3_0_6_released.rst
+++ b/2015/05/28/cakephp_2_6_6_and_3_0_6_released.rst
@@ -16,7 +16,7 @@ RequestHandlerComponent upgrade, or disable parsing XML payloads. To disable XML
 payload parsing you can do the following::
 
     // In a controller's beforeFilter
-    $this->RequestHandler->addInputType('xml', function() { return []; });
+    $this->RequestHandler->addInputType('xml', array(0 => function() { return array(); }));
 
 The above code will replace the built-in XML parsing with a no-op function. We'd
 like to thank Takeshi Terada for notifying us of this security issue using our


### PR DESCRIPTION
The proposed fix gave me a ``You must give a handler callback.`` exception.

``$handler`` needs to be an array and the actual handler needs to be set in the 0th index.
http://api.cakephp.org/2.6/class-RequestHandlerComponent.html#_addInputType
http://api.cakephp.org/3.0/class-Cake.Controller.Component.RequestHandlerComponent.html#_addInputType

Used old array syntax for people using old PHP versions...